### PR TITLE
Device UUID service discovery patch

### DIFF
--- a/android/src/main/java/com/example/wise_bluetooth_print/WiseBluetoothPrintPlugin.java
+++ b/android/src/main/java/com/example/wise_bluetooth_print/WiseBluetoothPrintPlugin.java
@@ -50,6 +50,7 @@ public class WiseBluetoothPrintPlugin implements FlutterPlugin, MethodCallHandle
             for (BluetoothDevice device : pairedDevices) {
               String deviceName = device.getName();
               String deviceHardwareAddress = device.getAddress();
+              device.fetchUuidsWithSdp();
               ParcelUuid[] uuids = device.getUuids();
               UUID socket = uuids[0].getUuid();
 


### PR DESCRIPTION
Android 11 devices fails on discovery without SDP. This patch does not break Android 10 devices as well.